### PR TITLE
Fix bulk update action type

### DIFF
--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -191,7 +191,7 @@ impl Action {
 
     pub fn update<S: Into<String>>(id: S, update: &ActionSource) -> Action {
         Action {
-            action:            ActionType::Delete,
+            action:            ActionType::Update,
             index:             None,
             doc_type:          None,
             id:                Some(id.into()),


### PR DESCRIPTION
The update type for bulk inserts was incorrectly set to Delete, I switched it to update and after some local testing, it appears to work fine now.