### PR TITLE
Implement Boolean type for JsonVal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,15 +282,17 @@ pub mod tests {
 
     #[derive(Debug, RustcDecodable, RustcEncodable)]
     pub struct TestDocument {
-        pub str_field: String,
-        pub int_field: i64
+        pub str_field:  String,
+        pub int_field:  i64,
+        pub bool_field: bool
     }
 
     impl TestDocument {
         pub fn new() -> TestDocument {
             TestDocument {
                 str_field: "I am a test".to_owned(),
-                int_field: 1
+                int_field: 1,
+                bool_field: true
             }
         }
 
@@ -303,13 +305,19 @@ pub mod tests {
             self.int_field = i;
             self
         }
+
+        pub fn with_bool_field(mut self, b: bool) -> TestDocument {
+            self.bool_field = b;
+            self
+        }
     }
 
     impl ToJson for TestDocument {
         fn to_json(&self) -> Json {
             let mut d = BTreeMap::new();
-            d.insert("str_field".to_owned(), self.str_field.to_json());
-            d.insert("int_field".to_owned(), self.int_field.to_json());
+            d.insert("str_field".to_owned(),  self.str_field.to_json());
+            d.insert("int_field".to_owned(),  self.int_field.to_json());
+            d.insert("bool_field".to_owned(), self.bool_field.to_json());
             Json::Object(d)
         }
     }
@@ -401,7 +409,8 @@ pub mod tests {
         let mut client = make_client();
         clean_db(&mut client, index_name);
         {
-            let doc = TestDocument::new().with_int_field(3);
+            let doc = TestDocument::new().with_int_field(3)
+                                         .with_bool_field(false);
             client
                 .index(index_name, "test_type")
                 .with_id("TEST_GETTING")
@@ -420,6 +429,7 @@ pub mod tests {
             let source:TestDocument = result.source().unwrap();
             assert_eq!(source.str_field, "I am a test");
             assert_eq!(source.int_field, 3);
+            assert_eq!(source.bool_field, false);
         }
     }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -296,7 +296,8 @@ pub enum JsonVal {
     String(String),
     I64(i64),
     U64(u64),
-    F64(f64)
+    F64(f64),
+    Boolean(bool)
 }
 
 impl ToJson for JsonVal {
@@ -305,7 +306,8 @@ impl ToJson for JsonVal {
             &JsonVal::String(ref str) => str.to_json(),
             &JsonVal::I64(i)          => Json::I64(i),
             &JsonVal::U64(u)          => Json::U64(u),
-            &JsonVal::F64(f)          => Json::F64(f)
+            &JsonVal::F64(f)          => Json::F64(f),
+            &JsonVal::Boolean(b)      => Json::Boolean(b)
         }
     }
 }
@@ -323,6 +325,7 @@ from_exp!(i32, JsonVal, from, JsonVal::I64(from as i64));
 from!(i64, JsonVal, I64);
 from_exp!(u32, JsonVal, from, JsonVal::U64(from as u64));
 from!(u64, JsonVal, U64);
+from!(bool, JsonVal, Boolean);
 
 impl<'a> From<&'a Json> for JsonVal {
     fn from(from: &'a Json) -> JsonVal {
@@ -331,7 +334,8 @@ impl<'a> From<&'a Json> for JsonVal {
             &Json::F64(f)        => JsonVal::F64(f),
             &Json::I64(f)        => JsonVal::I64(f),
             &Json::U64(f)        => JsonVal::U64(f),
-            _                    => panic!("Not a String, F64, I64 or U64")
+            &Json::Boolean(b)    => JsonVal::Boolean(b),
+            _                    => panic!("Not a String, F64, I64, U64 or Boolean")
         }
     }
 }


### PR DESCRIPTION
Add support for the [ES Boolean datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/boolean.html) to Rust `bool`eans.