### PR TITLE
Implement field mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "rs_es"
 hyper = "^0.7"
 rustc-serialize = "^0.3"
 log = "^0.3"
+maplit = "^0.1"
 
 [dev-dependencies]
 env_logger = "^0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ extern crate hyper;
 extern crate rustc_serialize;
 
 #[macro_use]
+extern crate maplit;
+
+#[macro_use]
 pub mod util;
 
 pub mod error;

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -23,19 +23,6 @@ use ::error::EsError;
 
 pub type Properties = HashMap<String, HashMap<String, String>>;
 
-#[macro_export]
-macro_rules! map(
-    { $($key:expr => $value:expr),+ } => {
-        {
-            let mut m = HashMap::new();
-            $(
-                m.insert($key, $value);
-            )+
-            m
-        }
-     };
-);
-
 /// An indexing operation
 pub struct MappingOperation<'a, 'b> {
     /// The HTTP client that this operation will use
@@ -58,9 +45,9 @@ impl<'a, 'b> MappingOperation<'a, 'b> {
     }
 
     pub fn send(&'b mut self) -> Result<MappingResult, EsError> {
-        let body = map! {
-            "mappings" => map! {
-                "sample" => map! {
+        let body = hashmap! {
+            "mappings" => hashmap! {
+                "sample" => hashmap! {
                     "properties" => self.properties
                 }
             }
@@ -91,13 +78,13 @@ pub mod tests {
 
         client.delete_op(&format!("/{}", index_name)).unwrap();
 
-        let mapping = map! {
-            "created_at".to_owned() => map! {
+        let mapping = hashmap! {
+            "created_at".to_owned() => hashmap! {
                 "type".to_owned() => "date".to_owned(),
                 "format".to_owned() => "epoch_second".to_owned()
             },
 
-            "title".to_owned() => map! {
+            "title".to_owned() => hashmap! {
                 "type".to_owned() => "string".to_owned(),
                 "index".to_owned() => "not_analyzed".to_owned()
             }

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Ben Ashford
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Implementation of ElasticSearch Mapping operation
+
+use std::collections::HashMap;
+
+use ::Client;
+use ::error::EsError;
+
+pub type Properties = HashMap<String, HashMap<String, String>>;
+
+#[macro_export]
+macro_rules! map(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+     };
+);
+
+/// An indexing operation
+pub struct MappingOperation<'a, 'b> {
+    /// The HTTP client that this operation will use
+    client:     &'a mut Client,
+
+    /// The index that will be created and eventually mapped
+    index:      &'b str,
+
+    /// The actual mapping
+    properties: &'b Properties
+}
+
+impl<'a, 'b> MappingOperation<'a, 'b> {
+    pub fn new(client: &'a mut Client, index: &'b str, properties: &'b Properties) -> MappingOperation<'a, 'b> {
+        MappingOperation {
+            client:     client,
+            index:      index,
+            properties: properties
+        }
+    }
+
+    pub fn send(&'b mut self) -> Result<MappingResult, EsError> {
+        let body = map! {
+            "mappings" => map! {
+                "sample" => map! {
+                    "properties" => self.properties
+                }
+            }
+        };
+
+        let url = format!("{}", self.index);
+        let (_, _) = try!(self.client.put_body_op(&url, &body));
+        Ok(MappingResult)
+    }
+}
+
+/// The result of a mapping operation
+#[derive(Debug)]
+pub struct MappingResult;
+
+#[cfg(test)]
+pub mod tests {
+    extern crate env_logger;
+
+    use std::collections::HashMap;
+
+    use super::MappingOperation;
+
+    #[test]
+    fn test_mapping() {
+        let index_name = "tests_test_mapping";
+        let mut client = ::tests::make_client();
+
+        client.delete_op(&format!("/{}", index_name)).unwrap();
+
+        let mapping = map! {
+            "created_at".to_owned() => map! {
+                "type".to_owned() => "date".to_owned(),
+                "format".to_owned() => "epoch_second".to_owned()
+            },
+
+            "title".to_owned() => map! {
+                "type".to_owned() => "string".to_owned(),
+                "index".to_owned() => "not_analyzed".to_owned()
+            }
+        };
+
+        let result = MappingOperation::new(&mut client, index_name, &mapping).send();
+        assert!(result.is_ok());
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -39,6 +39,7 @@ pub mod get;
 pub mod index;
 pub mod search;
 pub mod analyze;
+pub mod mapping;
 
 // Common utility functions
 


### PR DESCRIPTION
This PR aims to implement a basic support to field mapping ([Mapping](https://www.elastic.co/guide/en/elasticsearch/guide/current/mapping-intro.html)), solving in this way #11.

Considering the test provided in `operations/mapping.rs`, the index resulting will look like the following one:

```json
{
   "tests_test_mapping":{
      "aliases":{

      },
      "mappings":{
         "sample":{
            "properties":{
               "created_at":{
                  "type":"date",
                  "format":"epoch_second"
               },
               "title":{
                  "type":"string",
                  "index":"not_analyzed"
               }
            }
         }
      },
      "settings":{
         "index":{
            "creation_date":"1457142986574",
            "number_of_shards":"5",
            "number_of_replicas":"1",
            "uuid":"ymWlRAdtQQGtaqDBVJvdkw",
            "version":{
               "created":"2010199"
            }
         }
      },
      "warmers":{

      }
   }
}
```