### PR TITLE
Add execute() to DeleteOperation

### DIFF
--- a/src/operations/delete.rs
+++ b/src/operations/delete.rs
@@ -78,6 +78,17 @@ impl<'a, 'b> DeleteOperation<'a, 'b> {
                 Err(EsError::EsError(format!("Unexpected status: {}", status_code)))
         }
     }
+
+    /// Like `send`, but returns straight a `bool`ean value that will be true
+    /// if the operation succeed.
+    pub fn execute(&'a mut self) -> bool {
+        let url = format!("/{}/{}/{}{}",
+                          self.index,
+                          self.doc_type,
+                          self.id,
+                          self.options);
+        self.client.delete_op(&url).is_ok()
+    }
 }
 
 /// Result of a DELETE operation


### PR DESCRIPTION
Sorry for still bothering you!

Basically there are some kind of operations, like the deletion of an index, that will just return `{ "acknowledge": true }` in case of success.

This PR adds the function `execute` that return straight the status of the request.