### PR TITLE
make stable compile after syntex update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ nightly_without_ssl = ["serde_macros"]
 ssl = ["hyper/ssl"]
 
 [build-dependencies]
-quasi = "^0.8"
+quasi = "^0.9"
 serde_codegen = {version = "^0.7.1", optional = true}
-syntex = "^0.30"
+syntex = "^0.31"
 
 [dependencies]
 hyper = {version = "^0.8", default-features = false}

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -186,7 +186,7 @@ impl Client {
 #[cfg(test)]
 pub mod tests {
     extern crate env_logger;
-    pub extern crate regex;
+    extern crate regex;
 
     use std::env;
 

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -77,8 +77,6 @@ pub struct MappingResult;
 pub mod tests {
     extern crate env_logger;
 
-    use std::collections::HashMap;
-
     use super::MappingOperation;
 
     #[derive(Debug, Serialize)]


### PR DESCRIPTION
Right now, a checkout of rs-es or a cargo update on a project using rs-es 0.3.1 does not compile on stable (and potentially on others channels).

At the same time, remove 2 warnings.