### PR TITLE
Fixes the 'exists' query

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -407,4 +407,11 @@ mod tests {
         assert_eq!("{\"function_score\":{\"functions\":[{\"script_score\":{\"lang\":\"made_up\",\"params\":{\"A\":12},\"inline\":\"this_is_a_script\"}}]}}",
                    serde_json::to_string(&function_score_query).unwrap());
     }
+
+    #[test]
+    fn test_exists_query() {
+        let exists_query = Query::build_exists("name").build();
+        assert_eq!("{\"exists\":{\"field\":\"name\"}}",
+                   serde_json::to_string(&exists_query).unwrap());
+    }
 }

--- a/src/query/term.rs
+++ b/src/query/term.rs
@@ -243,13 +243,15 @@ impl RangeQuery {
 
 /// Exists query
 #[derive(Debug, Serialize)]
-pub struct ExistsQuery(FieldBasedQuery<NoOuter, NoOuter>);
+pub struct ExistsQuery {
+    field: String
+}
 
 impl Query {
     pub fn build_exists<A>(field: A) -> ExistsQuery
         where A: Into<String> {
 
-        ExistsQuery(FieldBasedQuery::new(field.into(), NoOuter, NoOuter))
+        ExistsQuery {field: field.into()}
     }
 }
 


### PR DESCRIPTION
the exists query was broken because it was transforming into

```
{
  "exists":
  {
    "my_field": ""
  }
}
```

and what we want is:

```json
{
  "exists":
  {
     "field": "my_field"
  }
}
```