### PR TITLE
Fix multi_match type name

### DIFF
--- a/src/query/full_text.rs
+++ b/src/query/full_text.rs
@@ -160,7 +160,7 @@ impl MatchQuery {
 pub struct MultiMatchQuery {
     fields: Vec<String>,
     query: JsonVal,
-    #[serde(skip_serializing_if="ShouldSkip::should_skip")]
+    #[serde(skip_serializing_if="ShouldSkip::should_skip", rename="type")]
     match_type: Option<MatchQueryType>,
     #[serde(skip_serializing_if="ShouldSkip::should_skip")]
     tie_breaker: Option<f64>,


### PR DESCRIPTION
This solves `[match] query does not support [match_type]"`.

Ref. https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html