### PR TITLE
add debug log to get json body

### DIFF
--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -124,6 +124,8 @@ macro_rules! es_body_op {
 
             info!("Doing {} on {}", stringify!($n), url);
             let json_string = try!(serde_json::to_string(body));
+            debug!("Body send: {}", &json_string);
+
             let url = self.full_url(url);
             let result = try!(self.http_client
                               .$cn(&url)


### PR DESCRIPTION
A lot of ES query are based on posted json, I find it useful to have a
mean to get it.

I'm not sure you'll want this (which can be quite verbose) in rs-es
though, it's up to you.