### PR TITLE
Send authorizations headers in bulk operations

### DIFF
--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -242,6 +242,7 @@ impl<'a, 'b, S> BulkOperation<'a, 'b, S>
         let result = try!(self.client.http_client
                           .post(&full_url)
                           .body(&body)
+                          .headers(self.client.headers.clone())
                           .send());
 
         let response = try!(do_req(result));


### PR DESCRIPTION
Bulk operations do not use `es_*!` macros for HTTP requests to ES and their requests lack of sending authorizations headers. This PR fixes this lack, but for the next iterations would be great finding a better solution to avoid cases like this.