### PR TITLE
Manage URLs with rust-url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ maplit = "^0.1"
 serde = "^0.8.9"
 serde_json = "^0.8.1"
 serde_macros = {version = "^0.8.9", optional = true}
+url = "^1.2"
 
 [dev-dependencies]
 env_logger = "^0.3"

--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ The `Client` wraps a single HTTP connection to a specified ElasticSearch host/po
 (At present there is no connection pooling, each client has one connection; if you need multiple connections you will need multiple clients.  This may change in the future).
 
 ```rust
-let mut client = Client::new("http://localhost");
+let mut client = Client::new("http://localhost:9200");
 ```
-
-You can select a different port (9200 is the default one) by adding it at the end of the URL (i.e. `http://localhost:9200`) or setting it with `client.set_port(9200)`.
 
 ### Operations
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ The `Client` wraps a single HTTP connection to a specified ElasticSearch host/po
 (At present there is no connection pooling, each client has one connection; if you need multiple connections you will need multiple clients.  This may change in the future).
 
 ```rust
-let mut client = Client::new("localhost", 9200);
+let mut client = Client::new("http://localhost");
 ```
+
+You can select a different port (9200 is the default one) by adding it at the end of the URL (i.e. `http://localhost:9200`) or setting it with `client.set_port(9200)`.
 
 ### Operations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ extern crate hyper;
 #[macro_use]
 extern crate maplit;
 
+extern crate url;
+
 #[cfg(feature = "serde_macros")]
 include!("lib.rs.in");
 

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -34,6 +34,8 @@ use serde::de::Deserialize;
 
 use error::EsError;
 
+use url::Url;
+
 pub trait EsResponse {
     fn status_code<'a>(&'a self) -> &'a StatusCode;
     fn read_response<R>(mut self) -> Result<R, EsError> where R: Deserialize;
@@ -89,12 +91,12 @@ pub fn do_req(resp: client::response::Response) -> Result<client::response::Resp
 /// ```
 /// use rs_es::Client;
 ///
-/// let mut client = Client::new("localhost", 9200);
+/// let mut client = Client::new("http://localhost");
 /// ```
 ///
 /// See the specific operations and their builder objects for details.
 pub struct Client {
-    base_url:    String,
+    base_url:    Url,
     http_client: hyper::Client,
     headers:     Headers
 }
@@ -140,31 +142,43 @@ macro_rules! es_body_op {
 
 impl Client {
     /// Create a new client
-    pub fn new(host: &str, port: u32) -> Client {
-        Client {
-            base_url:    format!("http://{}:{}", host, port),
-            http_client: hyper::Client::new(),
-            headers:     Self::auth_from_host(host)
+    pub fn new(host: &str) -> Client {
+        let mut url = Url::parse(host).unwrap();
+
+        if url.port().is_none() {
+            url.set_port(Some(9200)).unwrap();
         }
+
+        Client {
+            http_client: hyper::Client::new(),
+            headers:     Self::basic_auth(&url),
+            base_url:    url,
+        }
+    }
+
+    /// When a new client is created, the port is fetched by the URL,
+    /// and if it's not present, the 9200 will be picked.
+    /// This function replaces the selected port with the given one.
+    pub fn set_port(&mut self, port: u16) -> Result<(), ()> {
+        self.base_url.set_port(Some(port))
     }
 
     /// Add headers for the basic authentication to every request
     /// when given host's format is `USER:PASS@HOST`.
-    fn auth_from_host(host: &str) -> Headers {
+    fn basic_auth(url: &Url) -> Headers {
         let mut headers = Headers::new();
 
-        let tokens = host.split('@').collect::<Vec<&str>>();
-        if tokens.len() == 2 {
-            let auth = tokens[0].split(':').collect::<Vec<&str>>();
+        let username = url.username();
 
+        if !username.is_empty() {
             headers.set(
-               Authorization(
-                   Basic {
-                       username: auth[0].to_owned(),
-                       password: Some(auth[1].to_owned())
-                   }
-               )
-            );
+                Authorization(
+                    Basic {
+                        username: username.to_owned(),
+                        password: url.password().map(|p| p.to_owned())
+                    }
+                )
+            )
         }
 
         headers
@@ -173,7 +187,7 @@ impl Client {
     /// Take a nearly complete ElasticSearch URL, and stick the host/port part
     /// on the front.
     pub fn full_url(&self, suffix: &str) -> String {
-        format!("{}/{}", self.base_url, suffix)
+        format!("{}/{}", self.base_url.as_str(), suffix)
     }
 
     es_op!(get_op, get);
@@ -207,9 +221,9 @@ pub mod tests {
     pub fn make_client() -> Client {
         let hostname = match env::var("ES_HOST") {
             Ok(val) => val,
-            Err(_)  => "localhost".to_owned()
+            Err(_)  => "http://localhost:9200".to_owned()
         };
-        Client::new(&hostname, 9200)
+        Client::new(&hostname)
     }
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -78,7 +78,7 @@ pub fn do_req(resp: client::response::Response) -> Result<client::response::Resp
 /// at once.  This will be enforced by the borrow-checker as most methods are
 /// defined on `&mut self`.
 ///
-/// To create a `Client`, the hostname and port need to be specified.
+/// To create a `Client`, the URL needs to be specified.
 ///
 /// Each ElasticSearch API operation is defined as a method on `Client`.  Any
 /// compulsory parameters must be given as arguments to this method.  It returns
@@ -91,7 +91,7 @@ pub fn do_req(resp: client::response::Response) -> Result<client::response::Resp
 /// ```
 /// use rs_es::Client;
 ///
-/// let mut client = Client::new("http://localhost");
+/// let mut client = Client::new("http://localhost:9200");
 /// ```
 ///
 /// See the specific operations and their builder objects for details.
@@ -142,25 +142,14 @@ macro_rules! es_body_op {
 
 impl Client {
     /// Create a new client
-    pub fn new(host: &str) -> Client {
-        let mut url = Url::parse(host).unwrap();
+    pub fn new(url_s: &str) -> Result<Client, url::ParseError> {
+        let url = try!(Url::parse(url_s));
 
-        if url.port().is_none() {
-            url.set_port(Some(9200)).unwrap();
-        }
-
-        Client {
+        Ok(Client {
             http_client: hyper::Client::new(),
-            headers:     Self::basic_auth(&url),
-            base_url:    url,
-        }
-    }
-
-    /// When a new client is created, the port is fetched by the URL,
-    /// and if it's not present, the 9200 will be picked.
-    /// This function replaces the selected port with the given one.
-    pub fn set_port(&mut self, port: u16) -> Result<(), ()> {
-        self.base_url.set_port(Some(port))
+            headers:  Self::basic_auth(&url),
+            base_url: url
+        })
     }
 
     /// Add headers for the basic authentication to every request
@@ -184,10 +173,10 @@ impl Client {
         headers
     }
 
-    /// Take a nearly complete ElasticSearch URL, and stick the host/port part
-    /// on the front.
+    /// Take a nearly complete ElasticSearch URL, and stick
+    /// the URL on the front.
     pub fn full_url(&self, suffix: &str) -> String {
-        format!("{}/{}", self.base_url.as_str(), suffix)
+        self.base_url.join(suffix).unwrap().into_string()
     }
 
     es_op!(get_op, get);
@@ -223,7 +212,7 @@ pub mod tests {
             Ok(val) => val,
             Err(_)  => "http://localhost:9200".to_owned()
         };
-        Client::new(&hostname)
+        Client::new(&hostname).unwrap()
     }
 
     #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
In this way we can give all the responsibility to rust-url and allow HTTPS URLs.

Calling `as_str()` on a `Url` at every request should not be a problem as they store the slice upfront, based on the [docs](https://docs.rs/url/1.2.1/url/struct.Url.html#method.as_str).

This would be a breaking change obviously.