### PR TITLE
Bump serde and solve deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nightly_without_ssl = ["serde_derive"]
 ssl = ["hyper/ssl"]
 
 [build-dependencies]
-serde_codegen = {version = "^0.8.19", optional = true}
+serde_codegen = {version = "0.8", optional = true}
 
 [dependencies]
 hyper = {version = "^0.9", default-features = false}
@@ -30,7 +30,7 @@ log = "^0.3"
 maplit = "^0.1"
 serde = "^0.8.19"
 serde_json = "^0.8.1"
-serde_derive = {version = "^0.8.19", optional = true}
+serde_derive = {version = "0.8", optional = true}
 url = "^1.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@
 //! Warning: at the time of writing the majority of such APIs are currently
 //! unimplemented.
 
-#![cfg_attr(feature = "serde_derive", feature(proc_macro))]
-
 #[cfg(feature = "serde_derive")]
 #[macro_use]
 extern crate serde_derive;

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -38,7 +38,7 @@ use url::Url;
 
 pub trait EsResponse {
     fn status_code<'a>(&'a self) -> &'a StatusCode;
-    fn read_response<R>(mut self) -> Result<R, EsError> where R: Deserialize;
+    fn read_response<R>(self) -> Result<R, EsError> where R: Deserialize;
 }
 
 impl EsResponse for client::response::Response {


### PR DESCRIPTION
Hello!

This PR solves [this](https://github.com/rust-lang/rust/issues/35203) new deprecation and bump serde so that it compiles on the latest nightly. If you want we can still stick serde on the very latest version as you did for `0.8.19`.