### PR TITLE
Initial stab at converting to use Serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ hyper = "^0.10"
 hyper-openssl = { version = "^0.2", optional = true }
 log = "^0.3"
 maplit = "^0.1"
-serde = "^0.9"
-serde_json = "^0.9"
-serde_derive = "^0.9"
+serde = "^1.0"
+serde_json = "^1.0"
+serde_derive = "^1.0"
 url = "^1.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use hyper::status::StatusCode;
 use hyper::header::{Headers, Authorization, Basic};
 
 use serde::ser::Serialize;
-use serde::de::{Deserialize, DeserializeOwned};
+use serde::de::DeserializeOwned;
 
 use error::EsError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use hyper::status::StatusCode;
 use hyper::header::{Headers, Authorization, Basic};
 
 use serde::ser::Serialize;
-use serde::de::Deserialize;
+use serde::de::{Deserialize, DeserializeOwned};
 
 use error::EsError;
 
@@ -69,7 +69,7 @@ use url::Url;
 
 pub trait EsResponse {
     fn status_code(&self) -> &StatusCode;
-    fn read_response<R>(self) -> Result<R, EsError> where R: Deserialize;
+    fn read_response<R>(self) -> Result<R, EsError> where R: DeserializeOwned;
 }
 
 impl EsResponse for client::response::Response {
@@ -78,7 +78,7 @@ impl EsResponse for client::response::Response {
     }
 
     fn read_response<R>(self) -> Result<R, EsError>
-        where R: Deserialize {
+        where R: DeserializeOwned {
 
         Ok(serde_json::from_reader(self)?)
     }

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -289,7 +289,7 @@ impl<'de> Deserialize<'de> for ActionResult {
             fn visit_map<V>(self, mut visitor: V) -> Result<ActionResult, V::Error>
                 where V: MapAccess<'vde> {
 
-                let visited:Option<(String, ActionResultInner)> = visitor.next_value()?;
+                let visited:Option<(String, ActionResultInner)> = visitor.next_entry()?;
                 let (key, value) = match visited {
                     Some((key, value)) => (key, value),
                     None               => return Err(V::Error::custom("expecting at least one field"))

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -19,7 +19,7 @@
 use hyper::status::StatusCode;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde::de::{Error, MapVisitor, Visitor};
+use serde::de::{Error, MapAccess, Visitor};
 use serde_json;
 
 use ::{Client, EsResponse};
@@ -273,13 +273,13 @@ pub struct ActionResult {
     pub inner: ActionResultInner
 }
 
-impl Deserialize for ActionResult {
+impl<'de> Deserialize<'de> for ActionResult {
     fn deserialize<D>(deserializer: D) -> Result<ActionResult, D::Error>
-        where D: Deserializer {
+        where D: Deserializer<'de> {
 
         struct ActionResultVisitor;
 
-        impl Visitor for ActionResultVisitor {
+        impl<'vde> Visitor<'vde> for ActionResultVisitor {
             type Value = ActionResult;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -287,9 +287,9 @@ impl Deserialize for ActionResult {
             }
 
             fn visit_map<V>(self, mut visitor: V) -> Result<ActionResult, V::Error>
-                where V: MapVisitor {
+                where V: MapAccess<'vde> {
 
-                let visited:Option<(String, ActionResultInner)> = visitor.visit()?;
+                let visited:Option<(String, ActionResultInner)> = visitor.next_value()?;
                 let (key, value) = match visited {
                     Some((key, value)) => (key, value),
                     None               => return Err(V::Error::custom("expecting at least one field"))
@@ -312,7 +312,7 @@ impl Deserialize for ActionResult {
             }
         }
 
-        deserializer.deserialize(ActionResultVisitor)
+        deserializer.deserialize_any(ActionResultVisitor)
     }
 }
 

--- a/src/operations/get.rs
+++ b/src/operations/get.rs
@@ -16,7 +16,7 @@
 
 //! Implementation of the Get API
 
-use serde::Deserialize;
+use serde::de::{Deserialize, DeserializeOwned};
 
 use ::{Client, EsResponse};
 use ::error::EsError;
@@ -93,7 +93,7 @@ impl<'a, 'b> GetOperation<'a, 'b> {
     add_option!(with_version_type, "version_type");
 
     pub fn send<T>(&'b mut self) -> Result<GetResult<T>, EsError>
-        where T: Deserialize {
+        where T: DeserializeOwned {
 
         let url = format!("/{}/{}/{}{}",
                           self.index,
@@ -120,7 +120,8 @@ impl Client {
 
 /// The result of a GET request
 #[derive(Debug, Deserialize)]
-pub struct GetResult<T: Deserialize> {
+#[serde(bound(deserialize = ""))]
+pub struct GetResult<T: DeserializeOwned> {
     #[serde(rename="_index")]
     pub index:    String,
     #[serde(rename="_type")]

--- a/src/operations/get.rs
+++ b/src/operations/get.rs
@@ -16,7 +16,7 @@
 
 //! Implementation of the Get API
 
-use serde::de::{Deserialize, DeserializeOwned};
+use serde::de::DeserializeOwned;
 
 use ::{Client, EsResponse};
 use ::error::EsError;
@@ -120,8 +120,7 @@ impl Client {
 
 /// The result of a GET request
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = ""))]
-pub struct GetResult<T: DeserializeOwned> {
+pub struct GetResult<T> {
     #[serde(rename="_index")]
     pub index:    String,
     #[serde(rename="_type")]

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -25,7 +25,7 @@ use std::fmt::Debug;
 
 use hyper::status::StatusCode;
 
-use serde::de::{Deserialize, DeserializeOwned};
+use serde::de::DeserializeOwned;
 use serde::ser::{Serialize, Serializer};
 use serde_json::Value;
 
@@ -758,8 +758,7 @@ impl Client {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = ""))]
-pub struct SearchHitsHitsResult<T: DeserializeOwned> {
+pub struct SearchHitsHitsResult<T> {
     #[serde(rename="_index")]
     pub index: String,
     #[serde(rename="_type")]
@@ -781,8 +780,7 @@ pub struct SearchHitsHitsResult<T: DeserializeOwned> {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = ""))]
-pub struct SearchHitsResult<T: DeserializeOwned> {
+pub struct SearchHitsResult<T> {
     pub total: u64,
     pub hits:  Vec<SearchHitsHitsResult<T>>
 }
@@ -814,8 +812,7 @@ impl<T> SearchHitsResult<T>
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(bound(deserialize = ""))]
-pub struct SearchResultInterim<T: DeserializeOwned> {
+pub struct SearchResultInterim<T> {
     pub took:      u64,
     pub timed_out: bool,
 
@@ -848,7 +845,7 @@ impl<T> SearchResultInterim<T>
 }
 
 #[derive(Debug)]
-pub struct SearchResult<T: DeserializeOwned> {
+pub struct SearchResult<T> {
     pub took:      u64,
     pub timed_out: bool,
     pub shards:    ShardCountResult,
@@ -934,8 +931,7 @@ impl<'a, T> Iterator for ScanIterator<'a, T>
 /// See also the [official ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html)
 /// for proper use of this functionality.
 #[derive(Deserialize)]
-#[serde(bound(deserialize = ""))]
-pub struct ScanResultInterim<T: DeserializeOwned> {
+pub struct ScanResultInterim<T> {
     #[serde(rename="_scroll_id")]
     scroll_id:     String,
     took:      u64,
@@ -962,7 +958,7 @@ impl<T> ScanResultInterim<T>
     }
 }
 
-pub struct ScanResult<T: DeserializeOwned> {
+pub struct ScanResult<T> {
     pub scroll_id: String,
     pub took: u64,
     pub timed_out: bool,

--- a/src/units.rs
+++ b/src/units.rs
@@ -141,9 +141,9 @@ impl Default for Location {
     }
 }
 
-impl Deserialize for Location {
+impl<'de> Deserialize<'de> for Location {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer {
+        where D: Deserializer<'de> {
 
         // TODO - maybe use a specific struct?
         let mut raw_location = HashMap::<String, f64>::deserialize(deserializer)?;
@@ -189,9 +189,9 @@ impl Default for GeoBox {
     }
 }
 
-impl Deserialize for GeoBox {
+impl<'de> Deserialize<'de> for GeoBox {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer {
+        where D: Deserializer<'de> {
 
         // TODO - maybe use a specific struct?
         let mut raw_geo_box = HashMap::<String, Location>::deserialize(deserializer)?;
@@ -429,17 +429,17 @@ impl Serialize for JsonVal {
     }
 }
 
-impl Deserialize for JsonVal {
+impl<'de> Deserialize<'de> for JsonVal {
     fn deserialize<D>(deserializer: D) -> Result<JsonVal, D::Error>
-        where D: Deserializer {
+        where D: Deserializer<'de> {
 
-        deserializer.deserialize(JsonValVisitor)
+        deserializer.deserialize_any(JsonValVisitor)
     }
 }
 
 struct JsonValVisitor;
 
-impl de::Visitor for JsonValVisitor {
+impl<'de> de::Visitor<'de> for JsonValVisitor {
     type Value = JsonVal;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This is an initial attempt to convert the library to use Serde 1.0 (ref: #108).  It's the first time I've done this particular conversion, so there's a couple things that aren't yet finished.  In particular, there's some uses of `#[serde(bound(deserialize = ""))]` which I'm not happy about; that particular solution comes from https://github.com/serde-rs/serde/issues/891.

Any advice appreciated - or, if other folks want to build off this work, happy to have anyone use this as a starting point.