### PR TITLE
Add Debug derives to pub structs and enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub fn do_req(resp: client::response::Response) -> Result<client::response::Resp
 /// ```
 ///
 /// See the specific operations and their builder objects for details.
+#[derive(Debug)]
 pub struct Client {
     base_url:    Url,
     http_client: hyper::Client,

--- a/src/operations/analyze.rs
+++ b/src/operations/analyze.rs
@@ -21,6 +21,7 @@ use ::do_req;
 use ::{Client, EsResponse};
 use ::error::EsError;
 
+#[derive(Debug)]
 pub struct AnalyzeOperation<'a, 'b> {
     /// The HTTP client that this operation will use
     client:   &'a mut Client,

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -161,6 +161,7 @@ impl<S> Action<S> {
     add_inner_field!(with_retry_on_conflict, retry_on_conflict, u64);
 }
 
+#[derive(Debug)]
 pub struct BulkOperation<'a, 'b, S: 'b> {
     client:   &'a mut Client,
     index:    Option<&'b str>,
@@ -268,6 +269,7 @@ impl Client {
 }
 
 /// The result of specific actions
+#[derive(Debug)]
 pub struct ActionResult {
     pub action: ActionType,
     pub inner: ActionResultInner

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -32,6 +32,7 @@ use super::ShardCountResult;
 use super::common::{Options, OptionVal, VersionType};
 use std::fmt;
 
+#[derive(Debug)]
 pub enum ActionType {
     Index,
     Create,

--- a/src/operations/bulk.rs
+++ b/src/operations/bulk.rs
@@ -59,7 +59,7 @@ impl ToString for ActionType {
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct ActionOptions {
     #[serde(rename="_index", skip_serializing_if="ShouldSkip::should_skip")]
     index:             Option<String>,
@@ -83,7 +83,7 @@ pub struct ActionOptions {
     retry_on_conflict: Option<u64>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Action<X>(FieldBased<ActionType, ActionOptions, NoOuter>, Option<X>);
 
 impl<S> Action<S>
@@ -333,7 +333,7 @@ pub struct ActionResultInner {
 }
 
 /// The result of a bulk operation
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct BulkResult {
     pub errors: bool,
     pub items:  Vec<ActionResult>,

--- a/src/operations/common.rs
+++ b/src/operations/common.rs
@@ -24,6 +24,7 @@ use util::StrJoin;
 
 /// A newtype for the value of a URI option, this is to allow conversion traits
 /// to be implemented for it
+#[derive(Debug)]
 pub struct OptionVal(pub String);
 
 /// Conversion from `&str` to `OptionVal`
@@ -42,6 +43,7 @@ from_exp!(u64, OptionVal, from, OptionVal(from.to_string()));
 from_exp!(bool, OptionVal, from, OptionVal(from.to_string()));
 
 /// Every ES operation has a set of options
+#[derive(Debug)]
 pub struct Options<'a>(pub Vec<(&'a str, OptionVal)>);
 
 impl<'a> Options<'a> {

--- a/src/operations/common.rs
+++ b/src/operations/common.rs
@@ -92,6 +92,7 @@ macro_rules! add_option {
 }
 
 /// The [`version_type` field](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#index-versioning)
+#[derive(Debug)]
 pub enum VersionType {
     Internal,
     External,
@@ -123,6 +124,7 @@ impl ToString for VersionType {
 from_exp!(VersionType, OptionVal, from, OptionVal(from.to_string()));
 
 /// The consistency query parameter
+#[derive(Debug)]
 pub enum Consistency {
     One,
     Quorum,
@@ -140,6 +142,7 @@ impl From<Consistency> for OptionVal {
 }
 
 /// Values for `default_operator` query parameters
+#[derive(Debug)]
 pub enum DefaultOperator {
     And,
     Or

--- a/src/operations/delete.rs
+++ b/src/operations/delete.rs
@@ -22,6 +22,7 @@ use ::{Client, EsResponse};
 use ::error::EsError;
 use super::common::{Options, OptionVal};
 
+#[derive(Debug)]
 pub struct DeleteOperation<'a, 'b> {
     /// The HTTP client
     client:   &'a mut Client,

--- a/src/operations/get.rs
+++ b/src/operations/get.rs
@@ -39,6 +39,7 @@ impl From<Preference> for OptionVal {
 }
 
 /// An ES GET operation, to get a document by ID
+#[derive(Debug)]
 pub struct GetOperation<'a, 'b> {
     /// The HTTP connection
     client:   &'a mut Client,

--- a/src/operations/index.rs
+++ b/src/operations/index.rs
@@ -36,6 +36,7 @@ impl From<OpType> for OptionVal {
 }
 
 /// An indexing operation
+#[derive(Debug)]
 pub struct IndexOperation<'a, 'b, E: Serialize + 'b> {
     /// The HTTP client that this operation will use
     client:   &'a mut Client,

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -47,6 +47,7 @@ pub struct Analysis {
 }
 
 /// An indexing operation
+#[derive(Debug)]
 pub struct MappingOperation<'a, 'b> {
     /// The HTTP client that this operation will use
     client:    &'a mut Client,

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -34,13 +34,13 @@ use ::operations::GenericResult;
 pub type DocType<'a> = HashMap<&'a str, HashMap<&'a str, &'a str>>;
 pub type Mapping<'a> = HashMap<&'a str, DocType<'a>>;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Settings {
     pub number_of_shards: u32,
     pub analysis: Analysis
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Analysis {
     pub filter:   Map<String, Value>,
     pub analyzer: Map<String, Value>

--- a/src/operations/refresh.rs
+++ b/src/operations/refresh.rs
@@ -23,6 +23,7 @@ use ::error::EsError;
 
 use super::{format_multi, ShardCountResult};
 
+#[derive(Debug)]
 pub struct RefreshOperation<'a, 'b> {
     /// The HTTP client
     client: &'a mut Client,

--- a/src/operations/search/count.rs
+++ b/src/operations/search/count.rs
@@ -26,6 +26,7 @@ use ::operations::common::{Options, OptionVal};
 use ::operations::{format_indexes_and_types, ShardCountResult};
 
 /// Representing a count operation
+#[derive(Debug)]
 pub struct CountURIOperation<'a, 'b> {
     client: &'a mut Client,
     indexes: &'b [&'b str],
@@ -86,6 +87,7 @@ struct CountQueryOperationBody<'b> {
     query: Option<&'b Query>,
 }
 
+#[derive(Debug)]
 pub struct CountQueryOperation<'a, 'b> {
     /// The HTTP client
     client: &'a mut Client,

--- a/src/operations/search/count.rs
+++ b/src/operations/search/count.rs
@@ -80,7 +80,7 @@ impl<'a, 'b> CountURIOperation<'a, 'b> {
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 struct CountQueryOperationBody<'b> {
     /// The query
     #[serde(skip_serializing_if="ShouldSkip::should_skip")]

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -506,7 +506,7 @@ impl<'a> Source<'a> {
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 struct SearchQueryOperationBody<'b> {
     /// The query
     #[serde(skip_serializing_if="ShouldSkip::should_skip")]

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -144,10 +144,10 @@ impl<S: Into<String>> From<S> for Missing {
 
 /// Representing sort options for a specific field, can be combined with others
 /// to produce the full sort clause
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SortField(FieldBased<String, SortFieldInner, NoOuter>);
 
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct SortFieldInner {
     #[serde(skip_serializing_if="ShouldSkip::should_skip")]
     order:         Option<Order>,
@@ -204,7 +204,7 @@ impl ToString for SortField {
 
 /// Representing sort options for sort by geodistance
 // TODO - fix structure to represent reality
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct GeoDistance {
     field:         String,
     location:      OneOrMany<Location>,
@@ -256,7 +256,7 @@ impl GeoDistance {
 // TODO - fix structure
 // TODO - there are other 'Script's defined elsewhere, perhaps de-duplicate them
 // if it makes sense.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Script {
     script:      String,
     #[serde(rename="type")]
@@ -934,7 +934,7 @@ impl<'a, T> Iterator for ScanIterator<'a, T>
 ///
 /// See also the [official ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html)
 /// for proper use of this functionality.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ScanResultInterim<T> {
     #[serde(rename="_scroll_id")]
     scroll_id:     String,

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -43,6 +43,7 @@ use self::aggregations::AggregationsResult;
 use self::highlight::HighlightResult;
 
 /// Representing a search-by-uri option
+#[derive(Debug)]
 pub struct SearchURIOperation<'a, 'b> {
     client: &'a mut Client,
     indexes: &'b [&'b str],
@@ -321,6 +322,7 @@ impl ToString for SortBy {
 }
 
 /// A full sort clause
+#[derive(Debug)]
 pub struct Sort {
     fields: Vec<SortBy>
 }
@@ -559,6 +561,7 @@ struct SearchQueryOperationBody<'b> {
     version: Option<bool>
 }
 
+#[derive(Debug)]
 pub struct SearchQueryOperation<'a, 'b> {
     /// The HTTP client
     client: &'a mut Client,
@@ -863,6 +866,7 @@ impl<T> SearchResult<T>
     }
 }
 
+#[derive(Debug)]
 pub struct ScanIterator<'a, T: DeserializeOwned + Debug> {
     scan_result: ScanResult<T>,
     scroll:      Duration,
@@ -958,6 +962,7 @@ impl<T> ScanResultInterim<T>
     }
 }
 
+#[derive(Debug)]
 pub struct ScanResult<T> {
     pub scroll_id: String,
     pub took: u64,

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -52,6 +52,7 @@ pub struct SearchURIOperation<'a, 'b> {
 }
 
 /// Options for the various search_type parameters
+#[derive(Debug)]
 pub enum SearchType {
     DFSQueryThenFetch,
     DFSQueryAndFetch,
@@ -95,6 +96,7 @@ impl Serialize for Order {
 }
 
 /// The (Sort mode option)[https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_sort_mode_option].
+#[derive(Debug)]
 pub enum Mode {
     Min,
     Max,
@@ -116,6 +118,7 @@ impl Serialize for Mode {
 }
 
 /// Options for handling (missing values)[https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_missing_values]
+#[derive(Debug)]
 pub enum Missing {
     First,
     Last,
@@ -294,6 +297,7 @@ impl Script {
     }
 }
 
+#[derive(Debug)]
 pub enum SortBy {
     Field(SortField),
     Distance(GeoDistance),
@@ -459,6 +463,7 @@ impl<'a, 'b> SearchURIOperation<'a, 'b> {
 }
 
 /// Options for source filtering
+#[derive(Debug)]
 pub enum Source<'a> {
     /// Disable source documents
     Off,

--- a/src/operations/version.rs
+++ b/src/operations/version.rs
@@ -19,6 +19,7 @@
 use ::{Client, EsResponse};
 use ::error::EsError;
 
+#[derive(Debug)]
 pub struct VersionOperation<'a> {
     client: &'a mut Client
 }

--- a/src/operations/version.rs
+++ b/src/operations/version.rs
@@ -44,7 +44,7 @@ impl Client {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Version {
     pub number: String,
     pub build_hash: String,
@@ -53,7 +53,7 @@ pub struct Version {
     pub lucene_version: String
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct VersionResult {
     pub name: String,
     pub cluster_name: String,


### PR DESCRIPTION
This PR adds a `#[derive(Debug)]`  (or add `Debug` to the already existing `derive`s) to all `pub struct`s and `enum`s.

Commit 5429475 also add the derive to two private structs which is needed for the whole thing to compile. A manual `impl` might be better in the case where those structs contain information that should not be shown _at all_. Let me know if this is something to consider.

Closes #112 