### PR TITLE
Added ContentType header to client. Elasticsearch >6.0 requires it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub mod units;
 
 use hyper::client;
 use hyper::status::StatusCode;
-use hyper::header::{Headers, Authorization, Basic};
+use hyper::header::{Headers, Authorization, Basic, ContentType};
 
 use serde::ser::Serialize;
 use serde::de::DeserializeOwned;
@@ -212,6 +212,8 @@ impl Client {
                 )
             )
         }
+
+	headers.set(ContentType::json());
 
         headers
     }


### PR DESCRIPTION
I was surprised to see my bulk requests fail with:
```
EsServerError("406 Not Acceptable - {\"error\":\"Content-Type header [] is not supported\",\"status\":406}")
```

Found @josephDunne's fork just sitting there; I though it would be useful to upstream his work as to make interacting with ES 6 possible.