### PR TITLE
remove a warning about unused macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ extern crate serde_derive;
 
 extern crate serde;
 
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 
 #[macro_use]


### PR DESCRIPTION
this the macro in serde_json is used only in test, remove it  for non test.

solution found [here](https://github.com/rust-lang/rust/issues/44342#issuecomment-389054189)