### PR TITLE
[WIP] move from hyper to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,10 @@ exclude = ["devbox/**/*", "docker-dev.yml"]
 [lib]
 name = "rs_es"
 
-[features]
-default = ["ssl"]
-ssl = ["hyper-openssl"]
-
 [dependencies]
-hyper = "^0.10"
-hyper-openssl = { version = "^0.2", optional = true }
-log = "^0.3"
-maplit = "^0.1"
+log = "^0.4"
+maplit = "^1.0"
+reqwest = "^0.9"
 serde = "^1.0"
 serde_json = "^1.0"
 serde_derive = "^1.0"

--- a/src/operations/delete.rs
+++ b/src/operations/delete.rs
@@ -16,41 +16,43 @@
 
 //! Implementation of delete operations, both Delete-By-Query and Delete-By-Id
 
-use hyper::status::StatusCode;
+use reqwest::StatusCode;
 
-use ::{Client, EsResponse};
-use ::error::EsError;
-use super::common::{Options, OptionVal};
+use super::common::{OptionVal, Options};
+use error::EsError;
+use {Client, EsResponse};
 
 #[derive(Debug)]
 pub struct DeleteOperation<'a, 'b> {
     /// The HTTP client
-    client:   &'a mut Client,
+    client: &'a mut Client,
 
     /// The index
-    index:    &'b str,
+    index: &'b str,
 
     /// The type
     doc_type: &'b str,
 
     /// The ID
-    id:       &'b str,
+    id: &'b str,
 
     /// Optional options
-    options:  Options<'b>
+    options: Options<'b>,
 }
 
 impl<'a, 'b> DeleteOperation<'a, 'b> {
-    pub fn new(client:   &'a mut Client,
-               index:    &'b str,
-               doc_type: &'b str,
-               id:       &'b str) -> DeleteOperation<'a, 'b> {
+    pub fn new(
+        client: &'a mut Client,
+        index: &'b str,
+        doc_type: &'b str,
+        id: &'b str,
+    ) -> DeleteOperation<'a, 'b> {
         DeleteOperation {
-            client:   client,
-            index:    index,
+            client: client,
+            index: index,
             doc_type: doc_type,
-            id:       id,
-            options:  Options::new()
+            id: id,
+            options: Options::new(),
         }
     }
 
@@ -63,18 +65,17 @@ impl<'a, 'b> DeleteOperation<'a, 'b> {
     add_option!(with_timeout, "timeout");
 
     pub fn send(&'a mut self) -> Result<DeleteResult, EsError> {
-        let url = format!("/{}/{}/{}{}",
-                          self.index,
-                          self.doc_type,
-                          self.id,
-                          self.options);
+        let url = format!(
+            "/{}/{}/{}{}",
+            self.index, self.doc_type, self.id, self.options
+        );
         let response = self.client.delete_op(&url)?;
-        match response.status_code() {
-            &StatusCode::Ok =>
-                Ok(response.read_response()?),
-            _ =>
-                Err(EsError::EsError(format!("Unexpected status: {}",
-                                             response.status_code())))
+        match response.status() {
+            StatusCode::OK => Ok(response.read_response()?),
+            _ => Err(EsError::EsError(format!(
+                "Unexpected status: {}",
+                response.status()
+            ))),
         }
     }
 }
@@ -83,10 +84,12 @@ impl Client {
     /// Delete by ID
     ///
     /// See: https://www.elastic.co/guide/en/elasticsearch/reference/1.x/docs-delete.html
-    pub fn delete<'a>(&'a mut self,
-                      index:    &'a str,
-                      doc_type: &'a str,
-                      id:       &'a str) -> DeleteOperation {
+    pub fn delete<'a>(
+        &'a mut self,
+        index: &'a str,
+        doc_type: &'a str,
+        id: &'a str,
+    ) -> DeleteOperation {
         DeleteOperation::new(self, index, doc_type, id)
     }
 }
@@ -94,20 +97,20 @@ impl Client {
 /// Result of a DELETE operation
 #[derive(Debug, Deserialize)]
 pub struct DeleteResult {
-    pub found:    bool,
-    #[serde(rename="_index")]
-    pub index:    String,
-    #[serde(rename="_type")]
+    pub found: bool,
+    #[serde(rename = "_index")]
+    pub index: String,
+    #[serde(rename = "_type")]
     pub doc_type: String,
-    #[serde(rename="_id")]
-    pub id:       String,
-    #[serde(rename="_version")]
-    pub version:  u64
+    #[serde(rename = "_id")]
+    pub id: String,
+    #[serde(rename = "_version")]
+    pub version: u64,
 }
 
 #[cfg(test)]
 pub mod tests {
-    use ::tests::{clean_db, TestDocument, make_client};
+    use tests::{clean_db, make_client, TestDocument};
 
     #[test]
     fn test_delete() {
@@ -117,9 +120,11 @@ pub mod tests {
         clean_db(&mut client, index_name);
         let id = {
             let doc = TestDocument::new().with_int_field(4);
-            let result = client.index(index_name, "test_type")
+            let result = client
+                .index(index_name, "test_type")
                 .with_doc(&doc)
-                .send().unwrap();
+                .send()
+                .unwrap();
             result.id
         };
 

--- a/src/operations/delete_index.rs
+++ b/src/operations/delete_index.rs
@@ -16,10 +16,10 @@
 
 //! Implementation of ElasticSearch Delete Index operation
 
-use hyper::status::StatusCode;
+use reqwest::StatusCode;
 
-use ::{Client, EsResponse};
-use ::error::EsError;
+use error::EsError;
+use {Client, EsResponse};
 
 use super::GenericResult;
 
@@ -34,17 +34,19 @@ impl Client {
         let url = format!("/{}/", index);
         let response = self.delete_op(&url)?;
 
-        match response.status_code() {
-            &StatusCode::Ok => Ok(response.read_response()?),
-            _ => Err(EsError::EsError(format!("Unexpected status: {}",
-                                              response.status_code())))
+        match response.status() {
+            StatusCode::OK => Ok(response.read_response()?),
+            _ => Err(EsError::EsError(format!(
+                "Unexpected status: {}",
+                response.status()
+            ))),
         }
     }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use ::tests::{clean_db, TestDocument, make_client};
+    use tests::{clean_db, make_client, TestDocument};
 
     #[test]
     fn test_delete_index() {

--- a/src/operations/refresh.rs
+++ b/src/operations/refresh.rs
@@ -16,7 +16,7 @@
 
 //! Refresh an Index
 
-use hyper::status::StatusCode;
+use reqwest::StatusCode;
 
 use error::EsError;
 use {Client, EsResponse};
@@ -48,11 +48,11 @@ impl<'a, 'b> RefreshOperation<'a, 'b> {
     pub fn send(&mut self) -> Result<RefreshResult, EsError> {
         let url = format!("/{}/_refresh", format_multi(&self.indexes));
         let response = self.client.post_op(&url)?;
-        match response.status_code() {
-            &StatusCode::Ok => Ok(response.read_response()?),
+        match response.status() {
+            StatusCode::OK => Ok(response.read_response()?),
             _ => Err(EsError::EsError(format!(
                 "Unexpected status: {}",
-                response.status_code()
+                response.status()
             ))),
         }
     }

--- a/src/operations/search/count.rs
+++ b/src/operations/search/count.rs
@@ -16,7 +16,7 @@
 
 //! Implementations of the Count API
 
-use hyper::status::StatusCode;
+use reqwest::StatusCode;
 
 use error::EsError;
 use json::ShouldSkip;
@@ -74,11 +74,11 @@ impl<'a, 'b> CountURIOperation<'a, 'b> {
         );
         info!("Counting with: {}", url);
         let response = self.client.get_op(&url)?;
-        match response.status_code() {
-            &StatusCode::Ok => Ok(response.read_response()?),
+        match response.status() {
+            StatusCode::OK => Ok(response.read_response()?),
             _ => Err(EsError::EsError(format!(
                 "Unexpected status: {}",
-                response.status_code()
+                response.status()
             ))),
         }
     }
@@ -150,11 +150,11 @@ impl<'a, 'b> CountQueryOperation<'a, 'b> {
             self.options
         );
         let response = self.client.post_body_op(&url, &self.body)?;
-        match response.status_code() {
-            &StatusCode::Ok => Ok(response.read_response()?),
+        match response.status() {
+            StatusCode::OK => Ok(response.read_response()?),
             _ => Err(EsError::EsError(format!(
                 "Unexpected status: {}",
-                response.status_code()
+                response.status()
             ))),
         }
     }
@@ -252,8 +252,7 @@ mod tests {
                     .with_gte(2)
                     .with_lte(3)
                     .build(),
-            )
-            .send()
+            ).send()
             .unwrap();
         assert_eq!(2, doc_1.count);
 


### PR DESCRIPTION
As per issue #110, I have decided to migrate rs-es from hyper to reqwest. Initially I started porting to the latest hyper version, but quickly found that we will just end up copying `oneshot` completion code from reqwest, so I just decided to take the level of abstraction one level higher. This migration was surprisingly easy due to the structure of rs-es. The benefits of reqwest apart from maintainability are that ability to build custom clients and pass these to rs-es, similar to that of the elastic rust library.

I have left this as WIP as I have not updated the documentation, or thoroughly tested.