### PR TITLE
provide content-type for requests as required by ES6.x onwards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod units;
 
 use std::time;
 
-use reqwest::{RequestBuilder, StatusCode, Url};
+use reqwest::{header::CONTENT_TYPE, RequestBuilder, StatusCode, Url};
 
 use serde::{de::DeserializeOwned, ser::Serialize};
 
@@ -119,7 +119,7 @@ impl Client {
         if !username.is_empty() {
             method = method.basic_auth(username, self.base_url.password());
         }
-        let result = method.send()?;
+        let result = method.header(CONTENT_TYPE, "application/json").send()?;
         do_req(result)
     }
 }

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -741,7 +741,7 @@ impl<'a, 'b> SearchQueryOperation<'a, 'b> {
                             None => {
                                 return Err(EsError::EsError(
                                     "No aggs despite being in results".to_owned(),
-                                ))
+                                ));
                             }
                         };
                         Some(AggregationsResult::from(req_aggs, raw_aggs)?)
@@ -782,7 +782,7 @@ impl<'a, 'b> SearchQueryOperation<'a, 'b> {
                             None => {
                                 return Err(EsError::EsError(
                                     "No aggs despite being in results".to_owned(),
-                                ))
+                                ));
                             }
                         };
                         Some(AggregationsResult::from(req_aggs, raw_aggs)?)


### PR DESCRIPTION
It looks like the change #114 was lost during the refactor from `hyper` to `reqwest`.