### PR TITLE
improve geo_shape queries by using geojson crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_script:
 
 script:
    - |
-       travis-cargo build &&
-       travis-cargo test
+       travis-cargo build -- --all-features &&
+       travis-cargo test -- && travis-cargo test -- --all-features
 
 after_success:
   # measure code coverage and upload to coveralls.io (the verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ keywords = ["elasticsearch", "elastic"]
 exclude = [".gitignore", ".travis.yml", "docker-compose.yml"]
 edition = "2018"
 
+[features]
+default = []
+
+geo = ["geojson"]
+
 [lib]
 name = "rs_es"
 
@@ -19,6 +24,7 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+geojson = { version="0.15", optional=true}
 
 [dev-dependencies]
 env_logger = "0.6"


### PR DESCRIPTION
This requires to enable the feature `geo`.
The `geo` feature add a dependency to [geojson](https://github.com/georust/geojson/).
I didn't remove the previous implementation of `Shape` so there is no API breakage, we may want to mark it deprecated or remove it, let me know if you want me to update it.

close: #129 