### PR TITLE
Add debug message with body content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ macro_rules! es_body_op {
 
             log::info!("Doing {} on {}", stringify!($n), url);
             let json_string = serde_json::to_string(body)?;
+            log::debug!("With body: {}", &json_string);
 
             self.do_es_op(url, |url| {
                 self.http_client.$cn(url.clone()).body(json_string)


### PR DESCRIPTION
When building complex queries, it can be very useful to see the actual body sent to elasticsearch.  
Unfortunately such a debug message was removed in https://github.com/benashford/rs-es/commit/5dddca9558c123ef5b176ff19ca8956b5573b785#diff-b4aea3e418ccdb71239b96952d9cddb6L138

Unless I've missed another way ?