### PR TITLE
Make DecayOptions useful

### DIFF
--- a/src/query/compound.rs
+++ b/src/query/compound.rs
@@ -23,7 +23,7 @@ use crate::{json::ShouldSkip, units::OneOrMany};
 use super::{functions::Function, MinimumShouldMatch, Query, ScoreMode};
 
 /// BoostMode
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum BoostMode {
     Multiply,
     Replace,

--- a/src/query/functions.rs
+++ b/src/query/functions.rs
@@ -210,6 +210,20 @@ pub struct DecayOptions {
 }
 
 impl DecayOptions {
+    pub fn new<A, B>(origin: A, scale: B) -> DecayOptions
+    where
+        A: Into<Origin>,
+        B: Into<Scale>,
+    {
+        DecayOptions {
+            origin: origin.into(),
+            scale: scale.into(),
+            offset: None,
+            decay: None,
+            multi_value_mode: None,
+        }
+    }
+
     add_field!(with_offset, offset, Scale);
     add_field!(with_decay, decay, f64);
     add_field!(with_multi_value_mode, multi_value_mode, MultiValueMode);

--- a/src/query/functions.rs
+++ b/src/query/functions.rs
@@ -213,6 +213,24 @@ impl DecayOptions {
     add_field!(with_offset, offset, Scale);
     add_field!(with_decay, decay, f64);
     add_field!(with_multi_value_mode, multi_value_mode, MultiValueMode);
+
+    pub fn with_scale(mut self, val: Scale) -> Self {
+        self.scale = val;
+        self
+    }
+
+    pub fn with_origin(mut self, val: Origin) -> Self {
+        self.origin = val;
+        self
+    }
+
+    pub fn build<A: Into<String>>(self, field: A) -> Decay {
+        Decay(FieldBased::new(
+            field.into(),
+            self,
+            NoOuter,
+        ))
+    }
 }
 
 /// Decay functions
@@ -235,6 +253,10 @@ impl Function {
             },
             NoOuter,
         ))
+    }
+
+    pub fn build_decay_from_options<A: Into<String>>(field: A, options: DecayOptions) -> Decay {
+        options.build(field)
     }
 }
 


### PR DESCRIPTION
Currently, we can't set the `scale` field. This PR fixes it.