### PR TITLE
add a way to clone the client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ fn do_req(resp: reqwest::Response) -> Result<reqwest::Response, EsError> {
 /// ```
 ///
 /// See the specific operations and their builder objects for details.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Client {
     base_url: Url,
     http_client: reqwest::Client,


### PR DESCRIPTION
it's often usefull to be able to clone the client (especially to reuse the connection pool)