### PR TITLE
Enforce dependency versions which are compilable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ geo = ["geojson"]
 name = "rs_es"
 
 [dependencies]
-reqwest = "0.9"
-log = "0.4"
+reqwest = "0.9.18"
+log = "0.4.4"
 serde_json = "1.0"
 serde = {version = "1", features = ["derive"]}
 geojson = { version="0.16", optional=true}


### PR DESCRIPTION
Some of these when used by an application with other dependencies
are a bit too lax and choose older versions (which still suffice)
but fail to compile with modern compilers.