### PR TITLE
Minor changes to get majority of tests running with ES5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,23 @@ before_install:
   - sudo apt-get install openjdk-8-jre
   - which java
   - echo $JAVA_HOME
-  - curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.0.2/elasticsearch-2.0.2.zip && unzip elasticsearch-2.0.2.zip
-  - elasticsearch-2.0.2/bin/elasticsearch > /tmp/es.log &
+  - curl -O ${ES_DOWNLOAD_URL} && unzip elasticsearch-${ES_VERSION}.zip
+  - elasticsearch-${ES_VERSION}/bin/elasticsearch > /tmp/es.log &
 
 # As recommended here: http://docs.travis-ci.com/user/database-setup/#ElasticSearch
 before_script:
   - sleep 10
 
 script:
-   - |
-       cargo build --all-features &&
-       cargo test && cargo test --all-features
+   - cargo build ${FEATURES}
+   - cargo test ${FEATURES}
 
 env:
   global:
     - RUST_BACKTRACE=1
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
+  matrix:
+    - FEATURES="--features es5" ES_VERSION=5.6.14 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip
+    - FEATURES="--features es5,geo" ES_VERSION=5.6.14 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip
+    - FEATURES="" ES_VERSION=2.0.2 ES_DOWNLOAD_URL=https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.0.2/elasticsearch-2.0.2.zip
+    - FEATURES="--features geo" ES_VERSION=2.0.2 ES_DOWNLOAD_URL=https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.0.2/elasticsearch-2.0.2.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ geo = ["geojson"]
 name = "rs_es"
 
 [dependencies]
-reqwest = "0.9"
-log = "0.4"
+reqwest = "0.9.18"
+log = "0.4.4"
 serde_json = "1.0"
 serde = {version = "1", features = ["derive"]}
 geojson = { version="0.16", optional=true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 default = []
-
+es5 = []
 geo = ["geojson"]
 
 [lib]

--- a/src/operations/mapping.rs
+++ b/src/operations/mapping.rs
@@ -40,10 +40,12 @@ pub struct Settings {
     pub analysis: Analysis,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 pub struct Analysis {
     pub filter: Map<String, Value>,
     pub analyzer: Map<String, Value>,
+    pub tokenizer: Map<String, Value>,
+    pub char_filter: Map<String, Value>,
 }
 
 /// An indexing operation
@@ -229,6 +231,21 @@ pub mod tests {
                 })
                 .as_object()
                 .expect("by construction 'autocomplete' should be a map")
+                .clone(),
+                char_filter: serde_json::json! ({
+                    "char_filter": {
+                        "type": "pattern_replace",
+                        "pattern": ",",
+                        "replacement": " "
+                    }
+                })
+                .as_object()
+                .expect("by construction 'char_filter' should be a map")
+                .clone(),
+                tokenizer: serde_json::json! ({
+                })
+                .as_object()
+                .expect("by construction 'empty tokenizer' should be a map")
                 .clone(),
             },
         };

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -22,7 +22,7 @@
 
 use std::borrow::Cow;
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 use crate::util::StrJoin;
 
@@ -68,7 +68,7 @@ fn format_indexes_and_types<'a>(indexes: &[&'a str], types: &[&str]) -> Cow<'a, 
 
 /// Shared struct for operations that include counts of success/failed shards.
 /// This is returned within various other result structs.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ShardCountResult {
     pub total: u64,
     pub successful: u64,

--- a/src/operations/search/aggregations/bucket.rs
+++ b/src/operations/search/aggregations/bucket.rs
@@ -739,7 +739,7 @@ impl<'a> Serialize for BucketAggregation<'a> {
 }
 
 // results
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum BucketAggregationResult {
     Global(GlobalResult),
     Filter(FilterResult),
@@ -906,7 +906,7 @@ macro_rules! from_bucket_vector {
 }
 
 /// Global result
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct GlobalResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -924,7 +924,7 @@ impl GlobalResult {
 }
 
 /// Filter result
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FilterResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -941,7 +941,7 @@ impl FilterResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FiltersBucketResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -958,7 +958,7 @@ impl FiltersBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct FiltersResult {
     pub buckets: HashMap<String, FiltersBucketResult>,
 }
@@ -980,7 +980,7 @@ impl FiltersResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MissingResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -997,7 +997,7 @@ impl MissingResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct NestedResult {
     pub aggs: Option<AggregationsResult>,
 }
@@ -1012,7 +1012,7 @@ impl NestedResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ReverseNestedResult {
     pub aggs: Option<AggregationsResult>,
 }
@@ -1027,7 +1027,7 @@ impl ReverseNestedResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct ChildrenResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -1045,7 +1045,7 @@ impl ChildrenResult {
 }
 
 /// Terms result
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TermsResult {
     pub doc_count_error_upper_bound: u64,
     pub sum_other_doc_count: u64,
@@ -1062,7 +1062,7 @@ impl TermsResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct TermsBucketResult {
     pub key: JsonVal,
     pub doc_count: u64,
@@ -1092,7 +1092,7 @@ impl TermsBucketResult {
 
 // Range result objects
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct RangeBucketResult {
     pub from: Option<JsonVal>,
     pub to: Option<JsonVal>,
@@ -1113,7 +1113,7 @@ impl RangeBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct RangeResult {
     pub buckets: HashMap<String, RangeBucketResult>,
 }
@@ -1133,7 +1133,7 @@ impl RangeResult {
 
 // Date range result objects
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DateRangeBucketResult {
     pub from: Option<f64>,
     pub from_as_string: Option<String>,
@@ -1158,7 +1158,7 @@ impl DateRangeBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DateRangeResult {
     pub buckets: Vec<DateRangeBucketResult>,
 }
@@ -1172,7 +1172,7 @@ impl DateRangeResult {
 }
 
 /// Used for histogram results
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct HistogramBucketResult {
     pub key: String,
     pub doc_count: u64,
@@ -1191,7 +1191,7 @@ impl HistogramBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct HistogramResult {
     pub buckets: Vec<HistogramBucketResult>,
 }
@@ -1205,7 +1205,7 @@ impl HistogramResult {
 }
 
 // Date histogram results
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DateHistogramBucketResult {
     pub key_as_string: String,
     pub key: u64,
@@ -1226,7 +1226,7 @@ impl DateHistogramBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DateHistogramResult {
     pub buckets: Vec<DateHistogramBucketResult>,
 }
@@ -1244,7 +1244,7 @@ impl DateHistogramResult {
 }
 
 // GeoDistance results
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct GeoDistanceBucketResult {
     pub key: String,
     pub from: Option<f64>,
@@ -1267,7 +1267,7 @@ impl GeoDistanceBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct GeoDistanceResult {
     pub buckets: Vec<GeoDistanceBucketResult>,
 }
@@ -1280,7 +1280,7 @@ impl GeoDistanceResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct GeohashGridBucketResult {
     pub key: String,
     pub doc_count: u64,
@@ -1299,7 +1299,7 @@ impl GeohashGridBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct GeohashGridResult {
     pub buckets: Vec<GeohashGridBucketResult>,
 }

--- a/src/operations/search/aggregations/bucket.rs
+++ b/src/operations/search/aggregations/bucket.rs
@@ -20,7 +20,7 @@ use std::{borrow::ToOwned, collections::HashMap, marker::PhantomData};
 
 use serde::{
     ser::{SerializeMap, Serializer},
-    Serialize,
+    Serialize, Deserialize,
 };
 use serde_json::Value;
 
@@ -523,7 +523,7 @@ impl<'a> From<u64> for TimeZone<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub enum Interval {
     Year,
     Quarter,
@@ -592,7 +592,7 @@ impl<'a> DateHistogram<'a> {
 
 bucket_agg!(DateHistogram);
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct GeoDistanceInst {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     from: Option<f64>,
@@ -646,7 +646,7 @@ impl<'a> GeoDistance<'a> {
 bucket_agg!(GeoDistance);
 
 /// Geohash aggregation
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct GeohashGrid<'a> {
     field: &'a str,
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -739,7 +739,7 @@ impl<'a> Serialize for BucketAggregation<'a> {
 }
 
 // results
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum BucketAggregationResult {
     Global(GlobalResult),
     Filter(FilterResult),
@@ -906,7 +906,7 @@ macro_rules! from_bucket_vector {
 }
 
 /// Global result
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -924,7 +924,7 @@ impl GlobalResult {
 }
 
 /// Filter result
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FilterResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -941,7 +941,7 @@ impl FilterResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FiltersBucketResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -958,7 +958,7 @@ impl FiltersBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FiltersResult {
     pub buckets: HashMap<String, FiltersBucketResult>,
 }
@@ -980,7 +980,7 @@ impl FiltersResult {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MissingResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -997,7 +997,7 @@ impl MissingResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NestedResult {
     pub aggs: Option<AggregationsResult>,
 }
@@ -1012,7 +1012,7 @@ impl NestedResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ReverseNestedResult {
     pub aggs: Option<AggregationsResult>,
 }
@@ -1027,7 +1027,7 @@ impl ReverseNestedResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ChildrenResult {
     pub doc_count: u64,
     pub aggs: Option<AggregationsResult>,
@@ -1045,7 +1045,7 @@ impl ChildrenResult {
 }
 
 /// Terms result
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TermsResult {
     pub doc_count_error_upper_bound: u64,
     pub sum_other_doc_count: u64,
@@ -1062,7 +1062,7 @@ impl TermsResult {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TermsBucketResult {
     pub key: JsonVal,
     pub doc_count: u64,
@@ -1092,7 +1092,7 @@ impl TermsBucketResult {
 
 // Range result objects
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RangeBucketResult {
     pub from: Option<JsonVal>,
     pub to: Option<JsonVal>,
@@ -1113,7 +1113,7 @@ impl RangeBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RangeResult {
     pub buckets: HashMap<String, RangeBucketResult>,
 }
@@ -1133,7 +1133,7 @@ impl RangeResult {
 
 // Date range result objects
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DateRangeBucketResult {
     pub from: Option<f64>,
     pub from_as_string: Option<String>,
@@ -1158,7 +1158,7 @@ impl DateRangeBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DateRangeResult {
     pub buckets: Vec<DateRangeBucketResult>,
 }
@@ -1172,7 +1172,7 @@ impl DateRangeResult {
 }
 
 /// Used for histogram results
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HistogramBucketResult {
     pub key: String,
     pub doc_count: u64,
@@ -1191,7 +1191,7 @@ impl HistogramBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HistogramResult {
     pub buckets: Vec<HistogramBucketResult>,
 }
@@ -1205,7 +1205,7 @@ impl HistogramResult {
 }
 
 // Date histogram results
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DateHistogramBucketResult {
     pub key_as_string: String,
     pub key: u64,
@@ -1226,7 +1226,7 @@ impl DateHistogramBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DateHistogramResult {
     pub buckets: Vec<DateHistogramBucketResult>,
 }
@@ -1244,7 +1244,7 @@ impl DateHistogramResult {
 }
 
 // GeoDistance results
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GeoDistanceBucketResult {
     pub key: String,
     pub from: Option<f64>,
@@ -1267,7 +1267,7 @@ impl GeoDistanceBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GeoDistanceResult {
     pub buckets: Vec<GeoDistanceBucketResult>,
 }
@@ -1280,7 +1280,7 @@ impl GeoDistanceResult {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GeohashGridBucketResult {
     pub key: String,
     pub doc_count: u64,
@@ -1299,7 +1299,7 @@ impl GeohashGridBucketResult {
     add_aggs_ref!();
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GeohashGridResult {
     pub buckets: Vec<GeohashGridBucketResult>,
 }

--- a/src/operations/search/aggregations/metrics.rs
+++ b/src/operations/search/aggregations/metrics.rs
@@ -304,7 +304,7 @@ impl<'a> Serialize for MetricsAggregation<'a> {
 
 // results
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MetricsAggregationResult {
     Min(MinResult),
     Max(MaxResult),

--- a/src/operations/search/aggregations/metrics.rs
+++ b/src/operations/search/aggregations/metrics.rs
@@ -304,7 +304,7 @@ impl<'a> Serialize for MetricsAggregation<'a> {
 
 // results
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum MetricsAggregationResult {
     Min(MinResult),
     Max(MaxResult),
@@ -366,27 +366,27 @@ impl AggregationResult {
 // specific result objects
 
 /// Min Result
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct MinResult {
     pub value: JsonVal,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct MaxResult {
     pub value: JsonVal,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SumResult {
     pub value: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct AvgResult {
     pub value: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct StatsResult {
     pub count: u64,
     pub min: f64,
@@ -396,13 +396,13 @@ pub struct StatsResult {
 }
 
 /// Used by the `ExtendedStatsResult`
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Bounds {
     pub upper: f64,
     pub lower: f64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ExtendedStatsResult {
     pub count: u64,
     pub min: f64,
@@ -415,32 +415,32 @@ pub struct ExtendedStatsResult {
     pub std_deviation_bounds: Bounds,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ValueCountResult {
     pub value: u64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PercentilesResult {
     pub values: HashMap<String, f64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PercentileRanksResult {
     pub values: HashMap<String, f64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CardinalityResult {
     pub value: u64,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GeoBoundsResult {
     pub bounds: GeoBox,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ScriptedMetricResult {
     pub value: JsonVal,
 }

--- a/src/operations/search/aggregations/mod.rs
+++ b/src/operations/search/aggregations/mod.rs
@@ -25,7 +25,7 @@ pub mod metrics;
 use std::collections::HashMap;
 
 use serde::ser::{SerializeMap, Serializer};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use serde_json::{Map, Value};
 
 use crate::error::EsError;
@@ -127,7 +127,7 @@ impl<'a, A: Into<Aggregation<'a>>> From<(&'a str, A)> for Aggregations<'a> {
 /// The result of one specific aggregation
 ///
 /// The data returned varies depending on aggregation type
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum AggregationResult {
     /// Results of metrics aggregations
     Metrics(MetricsAggregationResult),
@@ -136,7 +136,7 @@ pub enum AggregationResult {
     Bucket(BucketAggregationResult),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AggregationsResult(HashMap<String, AggregationResult>);
 
 /// Loads a Json object of aggregation results into an `AggregationsResult`.

--- a/src/operations/search/aggregations/mod.rs
+++ b/src/operations/search/aggregations/mod.rs
@@ -127,7 +127,7 @@ impl<'a, A: Into<Aggregation<'a>>> From<(&'a str, A)> for Aggregations<'a> {
 /// The result of one specific aggregation
 ///
 /// The data returned varies depending on aggregation type
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum AggregationResult {
     /// Results of metrics aggregations
     Metrics(MetricsAggregationResult),
@@ -136,7 +136,7 @@ pub enum AggregationResult {
     Bucket(BucketAggregationResult),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct AggregationsResult(HashMap<String, AggregationResult>);
 
 /// Loads a Json object of aggregation results into an `AggregationsResult`.

--- a/src/operations/search/highlight.rs
+++ b/src/operations/search/highlight.rs
@@ -15,6 +15,7 @@
  */
 
 //! Implementation of ElasticSearch [highlight](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html)
+use crate::json::ShouldSkip;
 
 use std::collections::HashMap;
 
@@ -111,6 +112,7 @@ pub struct Setting {
     pub fragment_size: u32,
     pub number_of_fragments: u32,
     pub no_match_size: u32,
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     pub matched_fields: Option<Vec<String>>,
 }
 
@@ -184,8 +186,11 @@ impl Setting {
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct Highlight {
     pub fields: HashMap<String, Setting>,
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     pub pre_tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     pub post_tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     pub encoder: Option<Encoders>,
 }
 

--- a/src/operations/search/highlight.rs
+++ b/src/operations/search/highlight.rs
@@ -103,7 +103,9 @@ impl Serialize for TermVector {
 pub struct Setting {
     #[serde(rename = "type")]
     pub setting_type: Option<SettingTypes>,
+    #[cfg(not(feature = "es5"))]
     pub index_options: Option<IndexOptions>,
+    #[cfg(not(feature = "es5"))]
     pub term_vector: Option<TermVector>,
     pub force_source: bool,
     pub fragment_size: u32,
@@ -116,13 +118,17 @@ impl Default for Setting {
     fn default() -> Self {
         Setting {
             setting_type: None,
-            index_options: None,
-            term_vector: None,
             force_source: false,
             fragment_size: 150,
             number_of_fragments: 5,
             no_match_size: 0,
             matched_fields: None,
+
+            #[cfg(not(feature = "es5"))]
+            index_options: None,
+
+            #[cfg(not(feature = "es5"))]
+            term_vector: None,
         }
     }
 }
@@ -137,11 +143,13 @@ impl Setting {
         self
     }
 
+    #[cfg(not(feature = "es5"))]
     pub fn with_index_options(&mut self, index_options: IndexOptions) -> &mut Setting {
         self.index_options = Some(index_options);
         self
     }
 
+    #[cfg(not(feature = "es5"))]
     pub fn with_term_vector(&mut self, term_vector: TermVector) -> &mut Setting {
         self.term_vector = Some(term_vector);
         self

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -715,6 +715,7 @@ impl<'a, 'b> SearchQueryOperation<'a, 'b> {
     add_option!(with_ignore_unavailable, "ignore_unavailable");
     add_option!(with_allow_no_indices, "allow_no_indices");
     add_option!(with_expand_wildcards, "expand_wildcards");
+    add_option!(with_explain, "explain");
 
     /// Performs the search with the specified query and options
     pub fn send<T>(&'b mut self) -> Result<SearchResult<T>, EsError>
@@ -816,7 +817,7 @@ impl Client {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SearchHitsHitsResult<T> {
     #[serde(rename = "_index")]
     pub index: String,
@@ -830,6 +831,8 @@ pub struct SearchHitsHitsResult<T> {
     pub version: Option<u64>,
     #[serde(rename = "_source")]
     pub source: Option<Box<T>>,
+    #[serde(rename = "_explanation")]
+    pub explanation: Option<Value>,
     #[serde(rename = "_timestamp")]
     pub timestamp: Option<f64>,
     #[serde(rename = "_routing")]
@@ -838,7 +841,7 @@ pub struct SearchHitsHitsResult<T> {
     pub highlight: Option<HighlightResult>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SearchHitsResult<T> {
     pub total: u64,
     pub hits: Vec<SearchHitsHitsResult<T>>,
@@ -871,7 +874,7 @@ where
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SearchResultInterim<T> {
     pub took: u64,
     pub timed_out: bool,
@@ -905,7 +908,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SearchResult<T> {
     pub took: u64,
     pub timed_out: bool,

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -1478,6 +1478,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "es5", ignore(message = "need to fix mappings to not be text fields"))]
     fn test_highlight() {
         let mut client = make_client();
         let index_name = "test_highlight";
@@ -1528,6 +1529,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "es5", ignore(message = "need to fix mappings to not be text fields"))]
     fn test_bucket_aggs() {
         let mut client = make_client();
         let index_name = "test_bucket_aggs";
@@ -1649,6 +1651,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "es5", ignore(message = "need to fix mappings to not be text fields"))]
     fn test_sort() {
         let mut client = make_client();
         let index_name = "test_sort";

--- a/src/operations/search/mod.rs
+++ b/src/operations/search/mod.rs
@@ -453,6 +453,7 @@ impl<'a, 'b> SearchURIOperation<'a, 'b> {
     add_option!(with_allow_no_indices, "allow_no_indices");
     add_option!(with_expand_wildcards, "expand_wildcards");
 
+    #[cfg(not(feature = "es5"))]
     pub fn with_fields(&'b mut self, fields: &[&str]) -> &'b mut Self {
         self.options.push("fields", fields.iter().join(","));
         self
@@ -1201,6 +1202,7 @@ mod tests {
         assert_eq!(1, doc_1.hits.total);
         // TODO - add assertion for document contents
 
+        #[cfg(not(feature = "es5"))]
         let limited_fields: SearchResult<Value> = client
             .search_uri()
             .with_indexes(&[index_name])
@@ -1208,8 +1210,11 @@ mod tests {
             .with_fields(&["int_field"])
             .send()
             .unwrap();
+
+        #[cfg(not(feature = "es5"))]
         assert_eq!(1, limited_fields.hits.total);
         // TODO - add assertion for document contents
+
     }
 
     #[test]

--- a/src/operations/version.rs
+++ b/src/operations/version.rs
@@ -47,7 +47,10 @@ impl Client {
 pub struct Version {
     pub number: String,
     pub build_hash: String,
+    #[cfg(not(feature = "es5"))]
     pub build_timestamp: String,
+    #[cfg(feature = "es5")]
+    pub build_date: String,
     pub build_snapshot: bool,
     pub lucene_version: String,
 }
@@ -56,6 +59,8 @@ pub struct Version {
 pub struct VersionResult {
     pub name: String,
     pub cluster_name: String,
+    #[cfg(feature = "es5")]
+    pub cluster_uuid: String,
     pub version: Version,
     pub tagline: String,
 }
@@ -70,7 +75,7 @@ pub mod tests {
         let mut client = make_client();
         let result = client.version().send().unwrap();
 
-        let expected_regex = Regex::new(r"^\d\.\d\.\d$").unwrap();
+        let expected_regex = Regex::new(r"^\d\.\d\.\d+$").unwrap();
         assert_eq!(expected_regex.is_match(&result.version.number), true);
     }
 }

--- a/src/query/geo.rs
+++ b/src/query/geo.rs
@@ -423,6 +423,7 @@ pub mod tests {
             analysis: Analysis {
                 filter: serde_json::json!({}).as_object().unwrap().clone(),
                 analyzer: serde_json::json!({}).as_object().unwrap().clone(),
+                .. Default::default()
             },
         };
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -248,7 +248,7 @@ impl Serialize for GeoBox {
 
 /// A non-specific holder for an option which can either be a single thing, or
 /// multiple instances of that thing.
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub enum OneOrMany<T> {
     One(T),
     Many(Vec<T>),
@@ -288,7 +288,7 @@ impl<T> From<Vec<T>> for OneOrMany<T> {
 }
 
 /// DistanceType
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub enum DistanceType {
     SloppyArc,
     Arc,
@@ -310,7 +310,7 @@ impl Serialize for DistanceType {
 }
 
 /// DistanceUnit
-#[derive(Debug)]
+#[derive(Debug, Deserialize)]
 pub enum DistanceUnit {
     Mile,
     Yard,
@@ -356,7 +356,7 @@ impl Serialize for DistanceUnit {
 }
 
 /// Distance, both an amount and a unit
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Distance {
     amt: f64,
     unit: DistanceUnit,


### PR DESCRIPTION
This introduces a feature flag and test matrix so that we can start to ensure that queries work for ES5. I've kind of hacked `scan` for now as I've tried to be minimal in test changes but perhaps we can just have it not be defined when the flag is set and that we add alternative tests for the modern variants.

There are currently 3 tests which are ignored as they need changes to how the tests are written (as they don't seem to setup any mappings from what I can tell). Should we consider these a blocker for merging?